### PR TITLE
Numerics: endpoint-aware maximiser, demand monotonicity check, marginal cost near zero

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fredscape
 Title: Tidy Access to FRED Economic Data with Economist-Style Charts
-Version: 0.9.0
+Version: 0.9.1
 Authors@R:
     person("Matthew", "Jorden", email = "matthew.jorden@gmail.com",
            role = c("aut", "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# fredscape 0.9.1
+
+Numerical robustness, from the code review (#17). No API changes.
+
+* The market solvers are now two named primitives instead of one:
+  `maximise_on()` scores the endpoints and every downward crossing of a
+  marginal function by the integral and returns the best, so an upward-only
+  crossing (a profit minimum) is never returned and several crossings are
+  compared rather than the last one assumed; `find_crossing()` keeps the
+  last-downward-crossing rule for `third_degree()`'s search over the common
+  marginal-revenue level, where an integral means nothing.
+* `demand_fn()` checks on a coarse grid that inverse demand is finite and
+  decreasing, and refuses it otherwise.
+* `marginal_cost()` of a `production_cost()` built on a plain function no
+  longer differences below the inner solver's noise floor; at zero output it
+  reports the cost of the first thousandth of a unit rather than a
+  derivative that may not exist.
+
 # fredscape 0.9.0
 
 Econometrics (#21): estimating things from the series you fetched, in base R

--- a/R/discrimination.R
+++ b/R/discrimination.R
@@ -124,7 +124,7 @@ first_degree <- function(demand, cost) {
 #' Quantity at which a segment's marginal revenue equals m
 #' @noRd
 quantity_at_mr <- function(d, m) {
-  solve_on(function(q) marginal_revenue(d, q) - m, d$q_max)
+  maximise_on(function(q) marginal_revenue(d, q) - m, d$q_max)
 }
 
 #' @rdname price_discrimination
@@ -140,7 +140,7 @@ third_degree <- function(demands, cost) {
   # marginal cost (increasing returns) it can dip below zero and come back,
   # so bracket the crossing the same way the other structures do.
   gap <- function(m) marginal_cost(cost, total_at(m)) - m
-  m <- solve_on(gap, choke)
+  m <- find_crossing(gap, choke)
 
   q <- vapply(demands, quantity_at_mr, numeric(1), m = m)
   p <- mapply(function(d, qq) price_at(d, qq), demands, q)

--- a/R/market.R
+++ b/R/market.R
@@ -52,6 +52,20 @@ demand_fn <- function(p_of_q, q_max) {
     cli::cli_abort("{.arg p_of_q} must be a function of quantity.")
   }
   check_positive(q_max)
+  # Everything downstream -- inverting the curve, the marginal-revenue
+  # crossings, the surplus integrals -- assumes inverse demand slopes down.
+  # Check it on a coarse grid now rather than return plausible nonsense later.
+  probe <- p_of_q(seq(0, q_max, length.out = 50))
+  if (length(probe) == 1L) probe <- rep(probe, 50)
+  if (length(probe) != 50L || any(!is.finite(probe))) {
+    cli::cli_abort("{.arg p_of_q} must return one finite price per quantity on [0, q_max].")
+  }
+  if (any(diff(probe) > 1e-9 * max(1, abs(probe[1])))) {
+    cli::cli_abort(c(
+      "{.arg p_of_q} must be decreasing in quantity.",
+      "x" = "It rises somewhere on [0, {format(q_max)}]."
+    ))
+  }
   structure(
     list(p_of_q = p_of_q, q_max = q_max),
     class = c("general_demand", "demand")
@@ -367,8 +381,12 @@ marginal_cost.production_cost <- function(cost, q, ...) {
     out[pos] <- mc_production(cost$f, cost$w, cost$r, q[pos])
   }
   if (any(!pos)) {
-    # Marginal cost at zero output: the limit from the right.
-    out[!pos] <- mc_production(cost$f, cost$w, cost$r, rep(1e-6, sum(!pos)))
+    # At zero output the derivative may not exist (it is 0 or infinite for
+    # a Cobb-Douglas with non-unit returns), so report the cost of the
+    # first small sliver of output instead: a right-hand secant over
+    # [0, 1e-3], which is finite, scale-independent and honest.
+    sliver <- 1e-3
+    out[!pos] <- expenditure(cost$f, cost$w, cost$r, sliver) / sliver
   }
   out
 }
@@ -411,39 +429,73 @@ min_average_cost <- function(cost, q_max = NULL, ...) {
 
 ## Market structures ---------------------------------------------------------
 
-#' Solve g(q) = 0 on (0, upper]
+#' Scan a marginal function on (0, upper]
 #'
-#' `g` is a "net benefit of one more unit" function (MR - MC, P - MC, ...),
-#' so the outcome is where it crosses from positive to negative. That is not
-#' always the first crossing: with marginal cost falling from infinity (a
-#' production function with increasing returns) `g` runs negative, positive,
-#' negative, and the first sign change is the wrong one. So scan a grid,
-#' bracket the last downward crossing, and polish it with uniroot(). With no
-#' crossing at all, 0 if `g` is never positive and `upper` if it always is.
+#' Shared by the two solvers below: evaluate `g` on a grid, drop non-finite
+#' points, and locate every downward crossing (positive to non-positive).
 #'
+#' @return A list with the grid `q`, the values `g`, the indices `down` of
+#'   the grid points just before each downward crossing, and a `polish`
+#'   function that refines crossing `i` with uniroot().
 #' @noRd
-solve_on <- function(g, upper, n_grid = 200L) {
+scan_marginal <- function(g, upper, n_grid = 200L) {
   qs <- seq(upper * 1e-9, upper, length.out = n_grid)
   vals <- vapply(qs, g, numeric(1))
   keep <- is.finite(vals)
   qs <- qs[keep]
   vals <- vals[keep]
-  if (length(vals) == 0L) return(0)
+  down <- if (length(vals) > 1L) which(vals[-length(vals)] > 0 & vals[-1L] <= 0) else integer(0)
+  list(
+    q = qs, g = vals, down = down,
+    polish = function(i) stats::uniroot(g, c(qs[i], qs[i + 1L]), tol = 1e-10)$root
+  )
+}
 
-  polish <- function(i) stats::uniroot(g, c(qs[i], qs[i + 1L]), tol = 1e-10)$root
-  down <- which(vals[-length(vals)] > 0 & vals[-1L] <= 0)
-  if (length(down) > 0L) {
-    return(polish(down[length(down)]))
+#' Maximise the integral of a marginal function on [0, upper]
+#'
+#' `g` is a "net benefit of one more unit" (MR - MC, P - MC, ...), so the
+#' objective is its integral and the candidates for the maximum are the
+#' interval's endpoints and every point where `g` crosses from positive to
+#' negative. The integral is accumulated on the grid by the trapezoid rule
+#' and each candidate is scored; the best one wins. That handles the cases a
+#' first-crossing rule gets wrong: marginal cost falling from infinity
+#' (`g` runs -, +, -), several crossings, and a `g` that only ever crosses
+#' upward (a profit minimum, never returned -- one of the endpoints is).
+#'
+#' @noRd
+maximise_on <- function(g, upper, n_grid = 200L) {
+  s <- scan_marginal(g, upper, n_grid)
+  if (length(s$g) == 0L) return(0)
+  # Cumulative integral of g from 0, treating g as 0 on [0, q[1]].
+  cum <- c(0, cumsum(diff(s$q) * (utils::head(s$g, -1) + utils::tail(s$g, -1)) / 2))
+  candidates <- c(0, upper)
+  scores <- c(0, cum[length(cum)])
+  for (i in s$down) {
+    candidates <- c(candidates, s$polish(i))
+    scores <- c(scores, cum[i])
   }
-  if (all(vals > 0)) return(upper)
-  if (all(vals <= 0)) return(0)
-  polish(max(which(diff(sign(vals)) != 0)))
+  candidates[which.max(scores)]
+}
+
+#' Find where a decreasing-then-increasing gap function last crosses zero
+#'
+#' For a search over a *level* rather than a quantity (the common marginal
+#' revenue in [third_degree()]) the integral of `g` means nothing; the
+#' answer is simply the last downward crossing. With none, 0 if `g` is never
+#' positive and `upper` if it always is.
+#'
+#' @noRd
+find_crossing <- function(g, upper, n_grid = 200L) {
+  s <- scan_marginal(g, upper, n_grid)
+  if (length(s$g) == 0L) return(0)
+  if (length(s$down) > 0L) return(s$polish(s$down[length(s$down)]))
+  if (all(s$g > 0)) upper else 0
 }
 
 #' The quantity at which price equals industry marginal cost
 #' @noRd
 efficient_quantity <- function(d, cost, n) {
-  solve_on(function(Q) price_at(d, Q) - marginal_cost(cost, Q / n), d$q_max)
+  maximise_on(function(Q) price_at(d, Q) - marginal_cost(cost, Q / n), d$q_max)
 }
 
 #' Assemble the outcome object shared by every structure
@@ -543,7 +595,7 @@ NULL
 monopoly <- function(demand, cost) {
   check_demand(demand)
   check_cost(cost)
-  q <- solve_on(function(Q) marginal_revenue(demand, Q) - marginal_cost(cost, Q), demand$q_max)
+  q <- maximise_on(function(Q) marginal_revenue(demand, Q) - marginal_cost(cost, Q), demand$q_max)
   market_outcome("monopoly", demand, cost, n = 1, q_firm = q)
 }
 
@@ -559,7 +611,7 @@ cournot <- function(demand, cost, n) {
     Q <- n * q
     price_at(demand, Q) + q * demand_slope(demand, Q) - marginal_cost(cost, q)
   }
-  q <- solve_on(foc, demand$q_max / n)
+  q <- maximise_on(foc, demand$q_max / n)
   market_outcome(if (n == 1) "monopoly" else "cournot", demand, cost, n = n, q_firm = q)
 }
 
@@ -587,7 +639,7 @@ perfect_competition <- function(demand, cost, n = NULL) {
   if (!is.numeric(n) || length(n) != 1L || !is.finite(n) || n < 1) {
     cli::cli_abort("{.arg n} must be a positive number of firms, or NULL for the long run.")
   }
-  Q <- solve_on(function(QQ) price_at(demand, QQ) - marginal_cost(cost, QQ / n), demand$q_max)
+  Q <- maximise_on(function(QQ) price_at(demand, QQ) - marginal_cost(cost, QQ / n), demand$q_max)
   q <- Q / n
   note <- NULL
   if (q > 0 && price_at(demand, Q) < average_variable_cost(cost, q)) {

--- a/R/producer.R
+++ b/R/producer.R
@@ -111,7 +111,12 @@ mc_production.cobb_douglas <- function(f, w, r, q) {
 
 #' @noRd
 mc_production.default <- function(f, w, r, q) {
-  numeric_derivative(function(lv) expenditure(f, w, r, lv))(q)
+  # When expenditure() has no closed form it is a uniroot() around an
+  # optimize(), accurate to ~1e-9: a difference step must sit well above
+  # that noise floor or the derivative is garbage near zero output.
+  closed_form <- inherits(f, c("cobb_douglas", "ces", "leontief", "perfect_substitutes", "quasilinear"))
+  numeric_derivative(function(lv) expenditure(f, w, r, lv),
+                     h_min = if (closed_form) 0 else 1e-4)(q)
 }
 
 #' Draw average and marginal cost

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -14,11 +14,14 @@ check_unit_interval <- function(x, arg = rlang::caller_arg(x)) {
 #'
 #' @param f A function of one argument.
 #' @param h Relative step.
+#' @param h_min Absolute floor on the step. Leave at zero for a smooth
+#'   closed-form `f`; raise it when `f` is itself the output of a numerical
+#'   solver, whose tolerance would otherwise swamp a tiny difference.
 #' @return A function of `x`.
 #' @noRd
-numeric_derivative <- function(f, h = 1e-6) {
+numeric_derivative <- function(f, h = 1e-6, h_min = 0) {
   function(x) {
-    h_x <- h * pmax(abs(x), 1e-8)
+    h_x <- pmax(h * pmax(abs(x), 1e-8), h_min)
     x_lo <- pmax(x - h_x, 0)
     (f(x + h_x) - f(x_lo)) / (x + h_x - x_lo)
   }

--- a/tests/testthat/test-market.R
+++ b/tests/testthat/test-market.R
@@ -213,3 +213,62 @@ test_that("plot_market() builds for each structure and shades the right areas", 
   expect_s3_class(ggplot2::ggplot_build(plot_market(cournot(d, ushape, 3))), "ggplot_built")
   expect_error(plot_market(list()), "market_outcome")
 })
+
+## Numerics follow-ups (#17) -------------------------------------------------
+
+test_that("maximise_on() never returns a profit minimum", {
+  # Net benefit negative then positive: the integral is minimised at the
+  # crossing and maximised at an endpoint. The old rule returned 5.
+  g <- function(q) if (q <= 5) -1 else 1
+  expect_equal(maximise_on(g, 10), 10)
+  g2 <- function(q) if (q <= 8) -1 else 1
+  expect_equal(maximise_on(g2, 10), 0)
+})
+
+test_that("maximise_on() picks the best of several downward crossings", {
+  # Two humps: integral of g is larger after the second crossing.
+  g <- function(q) if (q < 2) 1 else if (q < 3) -0.5 else if (q < 7) 1 else -3
+  expect_equal(maximise_on(g, 10), 7, tolerance = 1e-6)
+  # ... and the first when the second hump is shallow.
+  g3 <- function(q) if (q < 2) 1 else if (q < 5) -1 else if (q < 6) 0.5 else -3
+  expect_equal(maximise_on(g3, 10), 2, tolerance = 1e-6)
+})
+
+test_that("maximise_on() keeps the endpoint behaviour and the IRS case", {
+  expect_equal(maximise_on(function(q) 1, 10), 10)
+  expect_equal(maximise_on(function(q) -1, 10), 0)
+  irs <- production_cost(cobb_douglas(0.6, 0.6, kind = "production"), w = 20, r = 30)
+  m <- monopoly(linear_demand(100, 1), irs)
+  expect_true(m$quantity > 0)
+  expect_equal(marginal_revenue(m$demand, m$quantity), marginal_cost(irs, m$quantity), tolerance = 1e-5)
+})
+
+test_that("find_crossing() returns the last downward crossing, or an endpoint", {
+  g <- function(m) if (m < 3) 1 else if (m < 6) -1 else if (m < 8) 1 else -1
+  expect_equal(find_crossing(g, 10), 8, tolerance = 1e-6)
+  expect_equal(find_crossing(function(m) 1, 10), 10)
+  expect_equal(find_crossing(function(m) -1, 10), 0)
+})
+
+test_that("demand_fn() rejects an inverse demand that is not decreasing", {
+  expect_error(demand_fn(function(q) 50 + q, 100), "decreasing")
+  expect_error(demand_fn(function(q) 100 - (q - 50)^2 / 25, 100), "decreasing")
+  expect_error(demand_fn(function(q) 100 / q, 100), "finite")
+  expect_error(demand_fn(function(q) 5, 100), NA)          # flat is allowed
+  expect_s3_class(demand_fn(function(q) 100 - q, 100), "demand")
+})
+
+test_that("marginal cost of a custom production function is usable near zero", {
+  # Same technology two ways: closed form and a plain function.
+  cd <- cobb_douglas(0.25, 0.25, kind = "production")
+  plain <- function(x, y) x^0.25 * y^0.25
+  a <- production_cost(cd, w = 5, r = 5)
+  b <- production_cost(plain, w = 5, r = 5)
+  for (q in c(1e-4, 1e-2, 1)) {
+    expect_true(marginal_cost(b, q) > 0)
+    expect_equal(marginal_cost(b, q), marginal_cost(a, q), tolerance = 1e-2)
+  }
+  # At zero: the cost of the first sliver, finite and positive, same for both.
+  expect_true(is.finite(marginal_cost(a, 0)) && marginal_cost(a, 0) > 0)
+  expect_equal(marginal_cost(b, 0), marginal_cost(a, 0), tolerance = 1e-3)
+})


### PR DESCRIPTION
## Summary

Closes #17 — the numerics follow-ups from the code review.

- **One primitive became two, deliberately.** `maximise_on()` scores the endpoints and every downward crossing of a marginal function by its integral and returns the best — so the review's counter-example (`g = −1 then +1`, which used to return the profit *minimum*) now returns an endpoint, and several crossings are compared rather than the last one assumed. `find_crossing()` keeps the last-downward-crossing rule for `third_degree()`'s search over the common marginal-revenue *level*, where an integral is not the objective. The review asked for a single primitive; that would have been wrong for the level search, and the two names say which problem each solves.
- **`demand_fn()` checks its precondition.** A 50-point probe refuses non-finite or increasing inverse demand at construction.
- **Marginal cost near zero for a custom production function.** The difference step is floored above the inner solver's noise when `expenditure()` has no closed form; at `q = 0` the cost of the first thousandth of a unit is reported instead of a derivative that may not exist.

## Verification

899 tests (24 new). `maximise_on()`: the counter-example, two-hump cases choosing the better crossing either way, endpoint behaviour, and the increasing-returns monopoly still satisfying `MR = MC`. `find_crossing()`: last crossing and both endpoints. `demand_fn()`: rejects rising, non-monotone and non-finite curves, accepts flat. Custom-`f` marginal cost positive and within 1% of the closed form at `q = 1e-4`. `R CMD check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)